### PR TITLE
Improve upload script robustness

### DIFF
--- a/upload_metrics_to_bigquery.sh
+++ b/upload_metrics_to_bigquery.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
 
 # CONFIGURABLE VALUES
 PROJECT_ID="your-gcp-project-id"


### PR DESCRIPTION
## Summary
- enhance `upload_metrics_to_bigquery.sh` to fail fast and handle whitespace

## Testing
- `bash -n upload_metrics_to_bigquery.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862355bac188320ae154cd3a5fd95f1