### PR TITLE
Add CLI args for dataset output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Push to GitHub and connect Cloud Build with a trigger using `cloudbuild.yaml`.
 Run the dataset builder to assemble training data:
 
 ```bash
-python build_dataset.py
+python build_dataset.py --output-dir data --output-file crowechem_dataset.jsonl
 ```
 
-The script creates `data/crowechem_dataset.jsonl` that can be consumed by your
-training jobs.
+Both arguments are optional. Without them the script creates
+`data/crowechem_dataset.jsonl`, which can be consumed by your training jobs.
 

--- a/build_dataset.py
+++ b/build_dataset.py
@@ -1,5 +1,6 @@
 import json
 import os
+import argparse
 
 try:
     from crowechem.core.data_sources import get_dataset
@@ -20,11 +21,11 @@ OUTPUT_DIR = "data"
 OUTPUT_FILE = "crowechem_dataset.jsonl"
 
 
-def main():
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
+def main(output_dir: str = OUTPUT_DIR, output_file: str = OUTPUT_FILE):
+    os.makedirs(output_dir, exist_ok=True)
     dataset = get_dataset()
     validate_dataset(dataset)
-    output_path = os.path.join(OUTPUT_DIR, OUTPUT_FILE)
+    output_path = os.path.join(output_dir, output_file)
     with open(output_path, "w") as f:
         for entry in dataset:
             f.write(json.dumps(entry) + "\n")
@@ -32,4 +33,16 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Build CroweChem dataset")
+    parser.add_argument(
+        "--output-dir",
+        default=OUTPUT_DIR,
+        help=f"Directory to store dataset (default: {OUTPUT_DIR})",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=OUTPUT_FILE,
+        help=f"Output filename (default: {OUTPUT_FILE})",
+    )
+    args = parser.parse_args()
+    main(output_dir=args.output_dir, output_file=args.output_file)


### PR DESCRIPTION
## Summary
- allow `build_dataset.py` to accept `--output-dir` and `--output-file`
- document usage of the new CLI options in the README

## Testing
- `python build_dataset.py --output-dir tempdata --output-file dataset.jsonl`
- `python build_dataset.py`
- `python -m py_compile build_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_686236569c54832083ece61f40101625